### PR TITLE
画像投稿機能の実装（一旦中止）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,8 @@ class ApplicationController < ActionController::Base
 
   private
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :publish_setting])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :publish_setting])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :publish_setting, :icon])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :publish_setting, :icon])
   end
 
   def move_to_index

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -47,7 +47,7 @@ class CardsController < ApplicationController
   private
 
   def card_params
-    params.require(:card).permit(:title, :text, :image, :publish_setting).merge(user_id: current_user.id)
+    params.require(:card).permit(:title, :text, :image, :publish_setting, images: []).merge(user_id: current_user.id)
   end
 
   def set_card

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -2,7 +2,7 @@ class Card < ApplicationRecord
   belongs_to :user
   has_many :users_tags_relations
   has_many :tags, through: :users_tags_relations
-  has_one_attached :image
+  has_many_attached :images
 
   with_options presence: true do
     validates :title, length: { maximum: 30, message: "は３０文字以内で記入してください"}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :cards
-  has_one_attached :image
+  has_one_attached :icon
 end

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -9,9 +9,15 @@
       <%= render "layouts/error_messages", model: f.object %>
       <%= f.text_field :title, placeholder: "カードのタイトル" %>
       <%= f.text_area :text, placeholder: "本文" %>
-      <%= f.label :image, "画像投稿", for: "file-input" do %>
+      <% if card.images.attached? %>
+        <% if card.images.attached? %>
+          <% card.images.each do |image| %>
+            <p class="card-images"><%= image_tag image.variant(strip: true, resize: "500x500>", quality: "85", interlace: "JPEG", colorspace: "sRGB").processed %><br></p>
+          <% end %>
+        <% end %>
+      <%= f.label :images, "画像投稿", for: "file-input" do %>
         <i class="far fa-images"></i>
-        <%= f.file_field :image, id: "file-input", style: "display: none;" %>
+        <%= f.file_field :images, id: "file-input", multiple: true, style: "display: none;" %>
       <% end %>
       公開設定：<%= f.check_box :publish_setting, {checked: true}, "true", "false" %>
       <%= f.submit "投稿内容を更新する"%>

--- a/app/views/cards/index.html.erb
+++ b/app/views/cards/index.html.erb
@@ -11,7 +11,7 @@
       <%= f.text_area :text, placeholder: "本文" %>
       <%= f.label :image, "画像投稿", for: "file-input" do %>
         <i class="far fa-images"></i>
-        <%= f.file_field :image, id: "file-input", style: "display: none;" %>
+        <%= f.file_field :images, id: "file-input", multiple: true, style: "display: none;" %>
       <% end %>
       公開設定：<%= f.check_box :publish_setting, {checked: true}, "true", "false" %>
       <%= f.submit "投稿する"%>
@@ -22,13 +22,17 @@
       <% if card.publish_setting == true || card.user == current_user %>
         <div class="content-post">
           <div class="card-user">
-            <div class="card-user-icon"><%= card.user.image %></div>
             <div class="card-user-name"><%= card.user.name %></div>
             <div class="card-post-time"><%= card.updated_at %></div>
           </div>
           <div class="card">
             <p class="card-title"><%= card.title %></p>
             <p class="card-text"><%= card.text %></p>
+            <% if card.images.attached? %>
+              <% card.images.each do |image| %>
+                <p class="card-images"><%= image_tag image.variant(strip: true, resize: "500x500>", quality: "85", interlace: "JPEG", colorspace: "sRGB").processed %><br></p>
+              <% end %>
+            <% end %>
             <% if user_signed_in? && card.user.id == current_user.id %>
               <%= link_to edit_card_path(card.id) do %>
                 <i class="far fa-edit"></i>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,8 +38,17 @@
 
   <div class="field">
     <%= f.label :publish_setting %><br />
-    カードの公開デフォルト設定：<%= f.radio_button :publish_setting, "true", checked: true %>公開<%= f.radio_button :publish_setting, "false" %>非公開
+    カード投稿の公開設定：<%= f.radio_button :publish_setting, "true", checked: true %>公開<%= f.radio_button :publish_setting, "false" %>非公開
   </div>
+
+  <!-- アイコン画像投稿機能
+  <div class="field">
+    <%# f.label :image, "画像投稿", for: "file-input" do %> %>
+      <i class="far fa-images"></i>
+      <%# f.file_field :image, id: "file-input" %>
+    <%# end %>
+  </div>
+  -->
 
   <div class="actions">
     <%= f.submit t('.update') %>


### PR DESCRIPTION
- ユーザー情報編集ページのビューを編集
- devise用のコントローラーにActiveStorageのための記述を追記（icon機能は未実装）
- cardsコントローラーで複数の画像を投稿できるように修正
- 投稿した画像がトップ・マイページ・カード編集ページで表示されるようビューを編集

###ブランチの設定にエラーが発生しているため、修復作業を行うので一旦マージする