### PR TITLE
ログインページの修飾

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -3,6 +3,7 @@ $breakpoint-down: 767px;
 $color: (main: #f5f5f5,
   white: #ffffff,
   logo: #4495e3,
+  logo_selected: #082d52,
   alert: #d92033,
   text_off: #757575,
   border: #e6ecf0,
@@ -36,7 +37,7 @@ $color: (main: #f5f5f5,
   border-radius: 4px;
 
   &>* {
-    padding: 5px 15px;
+    padding: 10px 15px;
 
     &:not(:last-child) {
       @include border_dashed();
@@ -59,13 +60,13 @@ $color: (main: #f5f5f5,
   @content;
 }
 
-@mixin publish($marginL: 0rem) {
+@mixin label($marginL: 0rem) {
   text-decoration: none;
   color: #{map-get($color, logo)};
   cursor: pointer;
 
   &:hover {
-    color: #3a6085;
+    color: #{map-get($color,logo_selected)};;
   }
 
   &.checked-publish {
@@ -153,7 +154,7 @@ header {
           border-bottom: #{map-get($color, logo)} solid 3px;
         }
 
-        &:not(:first-child)>a>svg {
+        &>a>svg {
           margin-right: 5px
         }
 
@@ -220,7 +221,7 @@ div.flash {
   }
 }
 
-/* メインラッパー・フラッシュメッセージ */
+/* メインラッパー */
 .main-wrapper {
   min-width: 300px;
   max-width: 600px;
@@ -284,7 +285,7 @@ h1 {
       display: flex;
 
       label {
-        @include publish($marginL: 1rem);
+        @include label($marginL: 1rem);
       }
     }
 
@@ -428,7 +429,7 @@ h1 {
       }
 
       &:active {
-        background-color: #3a6085;
+        background-color: #{map-get($color,logo_selected)};
       }
 
       &:hover,
@@ -458,7 +459,7 @@ h1 {
   }
 }
 
-/* ユーザーフォーム */
+/* ユーザーフォーム（新規登録，ログイン、ユーザー編集） */
 form {
   @include card() {
     display: flex;
@@ -486,7 +487,7 @@ form {
     }
 
     label {
-      @include publish($marginL: 0rem);
+      @include label($marginL: 0rem);
     }
   }
 
@@ -498,6 +499,24 @@ form {
 
     input[type=submit] {
       @include submit_btn();
+    }
+  }
+}
+
+.link-sign {
+  width: 100%;
+  min-width: 300px;
+  max-width: 600px;
+  margin: 1.5rem 0;
+  text-align: right;
+  
+  p a {
+    text-decoration: none;
+    color: #{map-get($color, logo)};
+
+    &:hover,
+    &:active {
+      color: #{map-get($color,logo_selected)};
     }
   }
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -39,3 +39,7 @@
     <%= f.submit t('.sign_up') %>
   </div>
 <% end %>
+
+<div class="link-sign">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,13 +2,13 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :email %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "登録したメールアドレスを入力してください" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%= f.label :password %>
+    <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワードを入力してください" %>
   </div>
 
   <!-- セッションを保持しますか？
@@ -25,4 +25,6 @@
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<div class="link-sign">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+  <p><%= link_to t(".sign_in"), new_session_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+  <p><%= link_to t(".sign_up"), new_registration_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+  <p><%= link_to t(".forgot_your_password"), new_password_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  <p><%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+  <p><%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
+    <p><%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %></p>
   <% end %>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,6 +7,7 @@
       <div class="hover-underline">
         <%= link_to root_path do %>
           <i class="fas fa-home fa-lg"></i>
+          サイトトップ
         <% end %>
       </div>
       <% if user_signed_in? %>


### PR DESCRIPTION
- ログインページも新規登録ページ同様のスタイルが適用されるよう修飾
- フォームのパディング縦幅を増やす
- 他deviceページへのリンクを修飾
- style.scssの変数名・カラー等を微調整